### PR TITLE
Folding JSON examples

### DIFF
--- a/draft-ietf-ccamp-mw-topo-yang.md
+++ b/draft-ietf-ccamp-mw-topo-yang.md
@@ -85,9 +85,11 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 # Microwave Topology YANG Data Model
 
 ## YANG Tree
-~~~~
+~~~~ ascii-art
 {::include ./mw.tree}
 ~~~~
+{: artwork-name="mw.tree"}
+
 
 ## Relationship between radio links and carriers
 A microwave radio link is always an aggregate of one or multiple carries, in various configurations/modes.  The supporting carriers are identified by its termination points and are listed in the container bundled-links as part of the te-link-config in the YANG Data Model for Traffic Engineering (TE) Topologies {{!RFC8795}} for a radio-link.  The exact configuration of the included carriers is further specified in the leaf mode (1+0, 2+0, 1+1, etc.) for the radio-link.  Appendix A includes an JSON example of how such a relationship can be modelled.
@@ -104,43 +106,39 @@ More specifically, admin-status and oper-status are recommended to be reported f
 TBD
 
 ## Microwave Topology YANG Module
-~~~~
-   <CODE BEGINS>file "ietf-microwave-topology@2021-10-20.yang"
+~~~~ yang
 {::include ./ietf-microwave-topology@2021-10-20.yang}
-   <CODE ENDS>
 ~~~~
+{: sourcecode-markers="true" sourcecode-name="ietf-microwave-topology@2021-10-20.yang"}
+
 
 #Bandwidth Availability Topology YANG Data Model
 
 ## YANG Tree
-~~~~
-   <CODE BEGINS>file "bw.tree"
+~~~~ ascii-art
 {::include ./bw.tree}
-   <CODE ENDS>
 ~~~~
+{: artwork-name="bw.tree"}
 
 ## Bandwidth Availability Topology YANG Data Module
-~~~~
-   <CODE BEGINS>file "ietf-bandwidth-availability-topology.yang"
+~~~~ yang
 {::include ./ietf-bandwidth-availability-topology.yang}
-   <CODE ENDS>
 ~~~~
+{: sourcecode-markers="true" sourcecode-name="ietf-bandwidth-availability-topology.yang"}
 
 # Termination Point to Interface Reference YANG Data Model
 
 ## YANG Tree
-~~~~
-   <CODE BEGINS>file "if.tree"
+~~~~ ascii-art
 {::include ./if.tree}
-   <CODE ENDS>
 ~~~~
+{: artwork-name="if.tree"}
 
 ## Termination Point to Interface Reference YANG Data Module
-~~~~
-   <CODE BEGINS>file "ietf-tp-interface-reference-topology.yang"
+~~~~ yang
 {::include ./ietf-tp-interface-reference-topology.yang}
-   <CODE ENDS>
 ~~~~
+{: sourcecode-markers="true" sourcecode-name="ietf-tp-interface-reference-topology.yang"}
 
 # Security Considerations
 
@@ -237,11 +235,10 @@ XML: N/A; the requested URI is an XML namespace.
    {{!RFC8345}}, Traffic Engineering (TE) Topologies model defined in
    {{!RFC8795}} and the associated Bandwidth Availability Model.
 
-~~~~
-   <CODE BEGINS>file "full.tree"
+~~~~ ascii-art
 {::include ./full.tree}
-   <CODE ENDS>
 ~~~~
+{: artwork-name="full.tree"}
 
 ## A topology with single microwave radio link
 
@@ -311,16 +308,15 @@ XML: N/A; the requested URI is an XML namespace.
 
 ~~~~~~~~~~
 
+~~~~ ascii-art
+{::include ./example.txt}
 ~~~~
-   <CODE BEGINS>file "example-fold.json"
-{::include ./example-fold.json}
-   <CODE ENDS>
+{: artwork-name="example.txt"}
+
+~~~~ ascii-art
+{::include ./example1p1.txt}
 ~~~~
-~~~~
-   <CODE BEGINS>file "exampleOnePlusOne-fold.json"
-{::include ./example1p1-fold.json}
-   <CODE ENDS>
-~~~~
+{: artwork-name="example1p1.txt"}
 
  Note that the examples above show one particular link
  (unidirectional) and not a complete network topology.

--- a/draft-ietf-ccamp-mw-topo-yang.txt
+++ b/draft-ietf-ccamp-mw-topo-yang.txt
@@ -5,14 +5,14 @@
 ccamp                                                         J. Ahlberg
 Internet-Draft                                              S. Mansfield
 Intended status: Standards Track                                Ericsson
-Expires: 16 October 2022                                           M. Ye
+Expires: 2 November 2022                                           M. Ye
                                                                  I. Busi
                                                      Huawei Technologies
                                                                    X. Li
                                                  NEC Laboratories Europe
                                                             D. Spreafico
                                                               Nokia - IT
-                                                           14 April 2022
+                                                              1 May 2022
 
 
                 A YANG Data Model for Microwave Topology
@@ -26,13 +26,6 @@ Abstract
    information from a termination point.
 
    TODO
-
-Discussion Venues
-
-   This note is to be removed before publishing as an RFC.
-
-   Source for this draft and an issue tracker can be found at
-   https://github.com/ietf-ccamp-wg/draft-ietf-ccamp-mw-topo-yang.
 
 Status of This Memo
 
@@ -49,51 +42,77 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 16 October 2022.
+   This Internet-Draft will expire on 2 November 2022.
 
 Copyright Notice
 
    Copyright (c) 2022 IETF Trust and the persons identified as the
    document authors.  All rights reserved.
 
+
+
+
+
+Ahlberg, et al.          Expires 2 November 2022                [Page 1]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
    This document is subject to BCP 78 and the IETF Trust's Legal
    Provisions Relating to IETF Documents (https://trustee.ietf.org/
    license-info) in effect on the date of publication of this document.
    Please review these documents carefully, as they describe your rights
    and restrictions with respect to this document.  Code Components
-   extracted from this document must include Simplified BSD License text
-   as described in Section 4.e of the Trust Legal Provisions and are
-   provided without warranty as described in the Simplified BSD License.
+   extracted from this document must include Revised BSD License text as
+   described in Section 4.e of the Trust Legal Provisions and are
+   provided without warranty as described in the Revised BSD License.
 
 Table of Contents
 
-   1.  Introduction
-     1.1.  Terminology and Definitions
-     1.2.  Tree Structure
-   2.  Requirements Language
-   3.  Microwave Topology YANG Data Model
-     3.1.  YANG Tree
-     3.2.  Relationship between radio links and carriers
-     3.3.  Relationship with client topology model
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
+     1.1.  Terminology and Definitions . . . . . . . . . . . . . . .   4
+     1.2.  Tree Structure  . . . . . . . . . . . . . . . . . . . . .   4
+   2.  Requirements Language . . . . . . . . . . . . . . . . . . . .   4
+   3.  Microwave Topology YANG Data Model  . . . . . . . . . . . . .   4
+     3.1.  YANG Tree . . . . . . . . . . . . . . . . . . . . . . . .   4
+     3.2.  Relationship between radio links and carriers . . . . . .   5
+     3.3.  Relationship with client topology model . . . . . . . . .   6
      3.4.  Applicability of the Data Model for Traffic Engineering
-           (TE) Topologies
-     3.5.  Model applicability to other technology
-     3.6.  Microwave Topology YANG Module
-   4.  Bandwidth Availability Topology YANG Data Model
-     4.1.  YANG Tree
-     4.2.  Bandwidth Availability Topology YANG Data Module
-   5.  Termination Point to Interface Reference YANG Data Model
-     5.1.  YANG Tree
-     5.2.  Termination Point to Interface Reference YANG Data Module
-   6.  Security Considerations
-   7.  IANA Considerations
-   8.  References
-     8.1.  Normative References
-     8.2.  Informative References
-   Appendix A.  Examples of the application of the Topology Models
-     A.1.  A tree for a complete Microwave Topology Model
-     A.2.  A topology with single microwave radio link
-   Authors' Addresses
+           (TE) Topologies . . . . . . . . . . . . . . . . . . . . .   6
+     3.5.  Model applicability to other technology . . . . . . . . .   6
+     3.6.  Microwave Topology YANG Module  . . . . . . . . . . . . .   6
+   4.  Bandwidth Availability Topology YANG Data Model . . . . . . .  13
+     4.1.  YANG Tree . . . . . . . . . . . . . . . . . . . . . . . .  13
+     4.2.  Bandwidth Availability Topology YANG Data Module  . . . .  13
+   5.  Termination Point to Interface Reference YANG Data Model  . .  16
+     5.1.  YANG Tree . . . . . . . . . . . . . . . . . . . . . . . .  16
+     5.2.  Termination Point to Interface Reference YANG Data
+           Module  . . . . . . . . . . . . . . . . . . . . . . . . .  16
+   6.  Security Considerations . . . . . . . . . . . . . . . . . . .  19
+   7.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  20
+   8.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  20
+     8.1.  Normative References  . . . . . . . . . . . . . . . . . .  20
+     8.2.  Informative References  . . . . . . . . . . . . . . . . .  21
+   Appendix A.  Examples of the application of the Topology
+           Models  . . . . . . . . . . . . . . . . . . . . . . . . .  22
+     A.1.  A tree for a complete Microwave Topology Model  . . . . .  22
+     A.2.  A topology with single microwave radio link . . . . . . .  24
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  43
+
+
+
+
+
+
+
+
+
+
+
+Ahlberg, et al.          Expires 2 November 2022                [Page 2]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
 
 1.  Introduction
 
@@ -140,6 +159,16 @@ Table of Contents
        information can be used to understand how changes in the
        performance/status of a microwave radio link affects traffic on
        higher layers.
+
+
+
+
+
+
+Ahlberg, et al.          Expires 2 November 2022                [Page 3]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
 
    2.  Propagation of relevant characteristics of a microwave radio
        link, such as bandwidth, to higher topology layers, where it e.g.
@@ -189,6 +218,14 @@ Table of Contents
 
 3.1.  YANG Tree
 
+
+
+
+Ahlberg, et al.          Expires 2 November 2022                [Page 4]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
    module: ietf-microwave-topology
 
    augment /nw:networks/nw:network/nw:network-types/tet:te-topology:
@@ -233,6 +270,18 @@ Table of Contents
    radio-link.  Appendix A includes an JSON example of how such a
    relationship can be modelled.
 
+
+
+
+
+
+
+
+Ahlberg, et al.          Expires 2 November 2022                [Page 5]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
 3.3.  Relationship with client topology model
 
    A microwave radio link carries a payload of traffic on higher
@@ -273,14 +322,21 @@ Table of Contents
 
 3.6.  Microwave Topology YANG Module
 
-   <CODE BEGINS>
-   file "ietf-microwave-topology@2021-10-20.yang"
+   <CODE BEGINS> file "ietf-microwave-topology@2021-10-20.yang"
     module ietf-microwave-topology {
       yang-version "1.1";
       namespace
       "urn:ietf:params:xml:ns:yang:ietf-microwave-topology";
 
       prefix "mwtopo";
+
+
+
+
+Ahlberg, et al.          Expires 2 November 2022                [Page 6]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
 
       import ietf-network {
         prefix "nw";
@@ -330,6 +386,14 @@ Table of Contents
 
         Copyright (c) 2019 IETF Trust and the persons identified as
         authors of the code.  All rights reserved.
+
+
+
+Ahlberg, et al.          Expires 2 November 2022                [Page 7]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
         Redistribution and use in source and binary forms, with or
         without modification, is permitted pursuant to, and subject to
         the license terms contained in, the Simplified BSD License set
@@ -378,6 +442,14 @@ Table of Contents
       }
 
       grouping microwave-radio-link-attributes {
+
+
+
+Ahlberg, et al.          Expires 2 November 2022                [Page 8]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
         description "Grouping used for attributes describing a microwave
                      radio link.";
         leaf mode {
@@ -426,6 +498,14 @@ Table of Contents
              frequency channels arrangement.
              Related to the data node channel-separation in RFC 8561.";
           reference
+
+
+
+Ahlberg, et al.          Expires 2 November 2022                [Page 9]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
             "ETSI EN 302 217-1 and
              RFC 8561: A YANG Data Model for Microwave Radio Link";
         }
@@ -474,6 +554,14 @@ Table of Contents
 
       grouping microwave-bandwidth {
         description "Grouping used for microwave bandwidth.";
+
+
+
+Ahlberg, et al.          Expires 2 November 2022               [Page 10]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
         leaf mw-bandwidth {
           type uint64;
           units "Kbps";
@@ -522,6 +610,14 @@ Table of Contents
                 description
                   "Denotes and describes a microwave radio link
                    termination point.";
+
+
+
+Ahlberg, et al.          Expires 2 November 2022               [Page 11]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
               }
             }
             case microwave-ctp {
@@ -570,6 +666,14 @@ Table of Contents
                 uses microwave-carrier-attributes;
                 description "Denotes and describes a microwave carrier";
               }
+
+
+
+Ahlberg, et al.          Expires 2 November 2022               [Page 12]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
             }
           }
         }
@@ -598,8 +702,6 @@ Table of Contents
 
 4.1.  YANG Tree
 
-   <CODE BEGINS>
-   file "bw.tree"
    module: ietf-bandwidth-availability-topology
 
    augment
@@ -608,12 +710,10 @@ Table of Contents
      |  +--rw availability      decimal64
      |  +--rw link-bandwidth?   uint64
      +--ro actual-bandwidth?    yang:gauge64
-   <CODE ENDS>
 
 4.2.  Bandwidth Availability Topology YANG Data Module
 
-   <CODE BEGINS>
-   file "ietf-bandwidth-availability-topology.yang"
+   <CODE BEGINS> file "ietf-bandwidth-availability-topology.yang"
    module ietf-bandwidth-availability-topology {
       yang-version "1.1";
       namespace
@@ -622,6 +722,14 @@ Table of Contents
 
       import ietf-yang-types {
         prefix yang;
+
+
+
+Ahlberg, et al.          Expires 2 November 2022               [Page 13]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
         reference
           "RFC 6991";
       }
@@ -670,6 +778,14 @@ Table of Contents
          conjunction with an instance of ietf-network-topology and its
 
          augmentations.
+
+
+
+Ahlberg, et al.          Expires 2 November 2022               [Page 14]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
          Example use cases include:
          - Defining bandwidth availability matrix for a microwave link
          - Defining bandwidth availability matrix for a LAG link
@@ -718,6 +834,14 @@ Table of Contents
             type uint64;
             units "Kbps";
 
+
+
+
+Ahlberg, et al.          Expires 2 November 2022               [Page 15]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
             description
               "The link bandwidth corresponding to the availability
                level";
@@ -752,24 +876,27 @@ Table of Contents
 
 5.1.  YANG Tree
 
-   <CODE BEGINS>
-   file "if.tree"
    module: ietf-tp-interface-reference-topology
 
    augment /nw:networks/nw:network/nw:node/nt:termination-point/tet:te:
      +--rw tp-to-interface-path?   -> /if:interfaces/interface/name
-   <CODE ENDS>
 
 5.2.  Termination Point to Interface Reference YANG Data Module
 
-   <CODE BEGINS>
-   file "ietf-tp-interface-reference-topology.yang"
+   <CODE BEGINS> file "ietf-tp-interface-reference-topology.yang"
    module ietf-tp-interface-reference-topology {
      yang-version "1.1";
       namespace
      "urn:ietf:params:xml:ns:yang:ietf-tp-interface-reference-topology";
 
       prefix "ifref";
+
+
+
+Ahlberg, et al.          Expires 2 November 2022               [Page 16]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
 
       import ietf-network {
         prefix "nw";
@@ -819,6 +946,14 @@ Table of Contents
       description
         "This is a module for defining a reference from a termination
          point in a te topology to a list element in interfaces
+
+
+
+Ahlberg, et al.          Expires 2 November 2022               [Page 17]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
          as defined in RFC 8343.
 
          Copyright (c) 2020 IETF Trust and the persons identified as
@@ -867,6 +1002,14 @@ Table of Contents
         description
           "Augmentation to add possibility to reference an element
            in the list of interfaces as defined by RFC 8343.";
+
+
+
+Ahlberg, et al.          Expires 2 November 2022               [Page 18]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
         uses tp-to-interface-ref;
       }
     }
@@ -913,6 +1056,16 @@ Table of Contents
    *  availability: A malicious client could attempt to modify the
       availability level which could modify the intended behavior.
 
+
+
+
+
+
+Ahlberg, et al.          Expires 2 November 2022               [Page 19]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
    *  link-bandwidth: A malicious client could attempt to modify the
       link bandwidth which could either provide more or less link
       bandwidth at the indicated availability level, changing the
@@ -954,84 +1107,101 @@ Table of Contents
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
               DOI 10.17487/RFC2119, March 1997,
-              <https://datatracker.ietf.org/doc/html/rfc2119>.
+              <https://www.rfc-editor.org/info/rfc2119>.
 
    [RFC3688]  Mealling, M., "The IETF XML Registry", BCP 81, RFC 3688,
               DOI 10.17487/RFC3688, January 2004,
-              <https://datatracker.ietf.org/doc/html/rfc3688>.
+              <https://www.rfc-editor.org/info/rfc3688>.
+
+
+
+
+
+Ahlberg, et al.          Expires 2 November 2022               [Page 20]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
 
    [RFC6020]  Bjorklund, M., Ed., "YANG - A Data Modeling Language for
               the Network Configuration Protocol (NETCONF)", RFC 6020,
               DOI 10.17487/RFC6020, October 2010,
-              <https://datatracker.ietf.org/doc/html/rfc6020>.
+              <https://www.rfc-editor.org/info/rfc6020>.
 
    [RFC6241]  Enns, R., Ed., Bjorklund, M., Ed., Schoenwaelder, J., Ed.,
               and A. Bierman, Ed., "Network Configuration Protocol
               (NETCONF)", RFC 6241, DOI 10.17487/RFC6241, June 2011,
-              <https://datatracker.ietf.org/doc/html/rfc6241>.
+              <https://www.rfc-editor.org/info/rfc6241>.
 
    [RFC6242]  Wasserman, M., "Using the NETCONF Protocol over Secure
               Shell (SSH)", RFC 6242, DOI 10.17487/RFC6242, June 2011,
-              <https://datatracker.ietf.org/doc/html/rfc6242>.
+              <https://www.rfc-editor.org/info/rfc6242>.
 
    [RFC8040]  Bierman, A., Bjorklund, M., and K. Watsen, "RESTCONF
               Protocol", RFC 8040, DOI 10.17487/RFC8040, January 2017,
-              <https://datatracker.ietf.org/doc/html/rfc8040>.
+              <https://www.rfc-editor.org/info/rfc8040>.
 
    [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
               2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
-              May 2017, <https://datatracker.ietf.org/doc/html/rfc8174>.
+              May 2017, <https://www.rfc-editor.org/info/rfc8174>.
 
    [RFC8341]  Bierman, A. and M. Bjorklund, "Network Configuration
               Access Control Model", STD 91, RFC 8341,
               DOI 10.17487/RFC8341, March 2018,
-              <https://datatracker.ietf.org/doc/html/rfc8341>.
+              <https://www.rfc-editor.org/info/rfc8341>.
 
    [RFC8343]  Bjorklund, M., "A YANG Data Model for Interface
               Management", RFC 8343, DOI 10.17487/RFC8343, March 2018,
-              <https://datatracker.ietf.org/doc/html/rfc8343>.
+              <https://www.rfc-editor.org/info/rfc8343>.
 
    [RFC8345]  Clemm, A., Medved, J., Varga, R., Bahadur, N.,
               Ananthakrishnan, H., and X. Liu, "A YANG Data Model for
               Network Topologies", RFC 8345, DOI 10.17487/RFC8345, March
-              2018, <https://datatracker.ietf.org/doc/html/rfc8345>.
+              2018, <https://www.rfc-editor.org/info/rfc8345>.
 
    [RFC8446]  Rescorla, E., "The Transport Layer Security (TLS) Protocol
               Version 1.3", RFC 8446, DOI 10.17487/RFC8446, August 2018,
-              <https://datatracker.ietf.org/doc/html/rfc8446>.
+              <https://www.rfc-editor.org/info/rfc8446>.
 
    [RFC8795]  Liu, X., Bryskin, I., Beeram, V., Saad, T., Shah, H., and
               O. Gonzalez de Dios, "YANG Data Model for Traffic
               Engineering (TE) Topologies", RFC 8795,
               DOI 10.17487/RFC8795, August 2020,
-              <https://datatracker.ietf.org/doc/html/rfc8795>.
+              <https://www.rfc-editor.org/info/rfc8795>.
 
 8.2.  Informative References
+
+
+
+
+Ahlberg, et al.          Expires 2 November 2022               [Page 21]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
 
    [RFC8330]  Long, H., Ye, M., Mirsky, G., D'Alessandro, A., and H.
               Shah, "OSPF Traffic Engineering (OSPF-TE) Link
               Availability Extension for Links with Variable Discrete
               Bandwidth", RFC 8330, DOI 10.17487/RFC8330, February 2018,
-              <https://datatracker.ietf.org/doc/html/rfc8330>.
+              <https://www.rfc-editor.org/info/rfc8330>.
 
    [RFC8340]  Bjorklund, M. and L. Berger, Ed., "YANG Tree Diagrams",
               BCP 215, RFC 8340, DOI 10.17487/RFC8340, March 2018,
-              <https://datatracker.ietf.org/doc/html/rfc8340>.
+              <https://www.rfc-editor.org/info/rfc8340>.
 
    [RFC8453]  Ceccarelli, D., Ed. and Y. Lee, Ed., "Framework for
               Abstraction and Control of TE Networks (ACTN)", RFC 8453,
               DOI 10.17487/RFC8453, August 2018,
-              <https://datatracker.ietf.org/doc/html/rfc8453>.
+              <https://www.rfc-editor.org/info/rfc8453>.
 
    [RFC8561]  Ahlberg, J., Ye, M., Li, X., Spreafico, D., and M.
               Vaupotic, "A YANG Data Model for Microwave Radio Link",
               RFC 8561, DOI 10.17487/RFC8561, June 2019,
-              <https://datatracker.ietf.org/doc/html/rfc8561>.
+              <https://www.rfc-editor.org/info/rfc8561>.
 
    [RFC8944]  Dong, J., Wei, X., Wu, Q., Boucadair, M., and A. Liu, "A
               YANG Data Model for Layer 2 Network Topologies", RFC 8944,
               DOI 10.17487/RFC8944, November 2020,
-              <https://datatracker.ietf.org/doc/html/rfc8944>.
+              <https://www.rfc-editor.org/info/rfc8944>.
 
 Appendix A.  Examples of the application of the Topology Models
 
@@ -1048,105 +1218,117 @@ A.1.  A tree for a complete Microwave Topology Model
    [RFC8345], Traffic Engineering (TE) Topologies model defined in
    [RFC8795] and the associated Bandwidth Availability Model.
 
-   <CODE BEGINS>
-   file "full.tree"
+  module: ietf-network
+    +--rw networks
+    +--rw network* [network-id]
+       +--rw network-id            network-id
+       +--rw network-types
+       |  +--rw tet:te-topology!
+       |     +--rw mwtopo:mw-topology!
+       +--rw supporting-network* [network-ref]
 
-   module: ietf-network
-     +--rw networks
-     +--rw network* [network-id]
-        +--rw network-id            network-id
-        +--rw network-types
-        |  +--rw tet:te-topology!
-        |     +--rw mwtopo:mw-topology!
-        +--rw supporting-network* [network-ref]
-        |  +--rw network-ref    -> /networks/network/network-id
-        +--rw node* [node-id]
-        |  +--rw node-id                 node-id
-        |  +--rw supporting-node* [network-ref node-ref]
-        |  |  +--rw network-ref
-        |  |  |           -> ../../../supporting-network/network-ref
-        |  |  +--rw node-ref       -> /networks/network/node/node-id
-        |  +--rw nt:termination-point* [tp-id]
-        |     +--rw nt:tp-id                           tp-id
-        |     +--rw nt:supporting-termination-point*
-        |     |  |                     [network-ref node-ref tp-ref]
-        |     |  +--rw nt:network-ref
-        |     |  |        -> ../../../nw:supporting-node/network-ref
-        |     |  +--rw nt:node-ref
-        |     |  |           -> ../../../nw:supporting-node/node-ref
-        |     |  +--rw nt:tp-ref
-        |     |        -> /nw:networks/network[nw:network-id=current()
-        |     |           /../network-ref]/node[nw:node-id=current()
-        |     |           /../node-ref]/termination-point/tp-id
-        |     +--rw tet:te!
-        |        +--rw tet:admin-status?  te-types:te-admin-status
-        |        +--rw tet:name?          string
-        |        +--ro tet:oper-status?   te-types:te-oper-status
-        |        +--ro tet:geolocation
-        |        |  +--ro tet:altitude?   int64
-        |        |  +--ro tet:latitude?   geographic-coordinate-degree
-        |        |  +--ro tet:longitude?  geographic-coordinate-degree
-        |        +--rw ifref:tp-to-interface-path?
-        |        |       -> /if:interfaces/if:interface/if:name
-        |        +--rw mwtopo:mw-tp-choice
-        |           +--rw (mwtopo:mw-tp-option)?
-        |              +--:(mwtopo:microwave-rltp)
-        |              |  +--rw mwtopo:microwave-rltp!
-        |              +--:(mwtopo:microwave-ctp)
-        |                 +--rw mwtopo:microwave-ctp!
-        +--rw nt:link* [link-id]
-           +--rw nt:link-id                link-id
-           +--rw nt:source
-           |  +--rw nt:source-node?   -> ../../../nw:node/node-id
-           |  +--rw nt:source-tp?
-           |         -> ../../../nw:node[nw:node-id=current()
-           |           /../source-node]/termination-point/tp-id
-           +--rw nt:destination
-           |  +--rw nt:dest-node?   -> ../../../nw:node/node-id
-           |  +--rw nt:dest-tp?
-           |        -> ../../../nw:node[nw:node-id=current()
-           |          /../dest-node]/termination-point/tp-id
-           +--rw tet:te!
-              +--rw (tet:bundle-stack-level)?
-              |  +--:(tet:bundle)
-              |     +--rw tet:bundled-links
-              |        +--rw tet:bundled-link* [sequence]
-              |           +--rw tet:sequence      uint32
-              |           +--rw tet:src-tp-ref?   -> ../../../../../
-              |           |     nw:node[nw:node-id current()/../../..
-              |           |     /../nt:source/source-node]/
-              |           |     termination-point/tp-id
-              |           +--rw tet:des-tp-ref?   -> ../../../../../
-              |                 nw:node[nw:node-id = current()/../../
-              |                 ../../nt:destination/dest-node]/
-              |                 termination-point/tp-id
-              +--rw tet:te-link-attributes
-              |  +--rw tet:name?            string
-              |  +--rw tet:admin-status?    te-types:te-admin-status
-              |  +--rw tet:max-link-bandwidth
-              |  |  +--rw tet:te-bandwidth
-              |  |     +--rw (tet:technology)?
-              |  |        +--:(mwtopo:microwave)
-              |  |           +--ro mwtopo:mw-bandwidth? uint64
-              |  +--rw mwtopo:mw-link-choice
-              |  |   +--rw (mwtopo:mw-link-option)?
-              |  |     +--:(mwtopo:microwave-radio-link)
-              |  |     |  +--rw mwtopo:microwave-radio-link!
-              |  |     |     +--rw mwtopo:mode?   identityref
-              |  |     +--:(mwtopo:microwave-carrier)
-              |  |        +--rw mwtopo:microwave-carrier!
-              |  |           +--rw mwtopo:tx-frequency?       uint32
-              |  |           +--rw mwtopo:rx-frequency?       uint32
-              |  |           +--rw mwtopo:channel-separation? uint32
-              |  |           +--rw mwtopo:actual-tx-cm?       identityref
-              |  |           +--rw mwtopo:actual-snir?        decimal64
-              |  |           +--rw mwtopo:actual-transmitted-level? power
-              |  +--rw bwatopo:link-availability* [availability]
-              |  |  +--rw bwatopo:availability      decimal64
-              |  |  +--rw bwatopo:link-bandwidth?   uint64
-              |  +--rw bwatopo:actual-bandwidth?    yang:gauge64
-              +--ro tet:oper-status?         te-types:te-oper-status
-   <CODE ENDS>
+
+
+Ahlberg, et al.          Expires 2 November 2022               [Page 22]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
+       |  +--rw network-ref    -> /networks/network/network-id
+       +--rw node* [node-id]
+       |  +--rw node-id                 node-id
+       |  +--rw supporting-node* [network-ref node-ref]
+       |  |  +--rw network-ref
+       |  |  |           -> ../../../supporting-network/network-ref
+       |  |  +--rw node-ref       -> /networks/network/node/node-id
+       |  +--rw nt:termination-point* [tp-id]
+       |     +--rw nt:tp-id                           tp-id
+       |     +--rw nt:supporting-termination-point*
+       |     |  |                     [network-ref node-ref tp-ref]
+       |     |  +--rw nt:network-ref
+       |     |  |        -> ../../../nw:supporting-node/network-ref
+       |     |  +--rw nt:node-ref
+       |     |  |           -> ../../../nw:supporting-node/node-ref
+       |     |  +--rw nt:tp-ref
+       |     |        -> /nw:networks/network[nw:network-id=current()
+       |     |           /../network-ref]/node[nw:node-id=current()
+       |     |           /../node-ref]/termination-point/tp-id
+       |     +--rw tet:te!
+       |        +--rw tet:admin-status?  te-types:te-admin-status
+       |        +--rw tet:name?          string
+       |        +--ro tet:oper-status?   te-types:te-oper-status
+       |        +--ro tet:geolocation
+       |        |  +--ro tet:altitude?   int64
+       |        |  +--ro tet:latitude?   geographic-coordinate-degree
+       |        |  +--ro tet:longitude?  geographic-coordinate-degree
+       |        +--rw ifref:tp-to-interface-path?
+       |        |       -> /if:interfaces/if:interface/if:name
+       |        +--rw mwtopo:mw-tp-choice
+       |           +--rw (mwtopo:mw-tp-option)?
+       |              +--:(mwtopo:microwave-rltp)
+       |              |  +--rw mwtopo:microwave-rltp!
+       |              +--:(mwtopo:microwave-ctp)
+       |                 +--rw mwtopo:microwave-ctp!
+       +--rw nt:link* [link-id]
+          +--rw nt:link-id                link-id
+          +--rw nt:source
+          |  +--rw nt:source-node?   -> ../../../nw:node/node-id
+          |  +--rw nt:source-tp?
+          |         -> ../../../nw:node[nw:node-id=current()
+          |           /../source-node]/termination-point/tp-id
+          +--rw nt:destination
+          |  +--rw nt:dest-node?   -> ../../../nw:node/node-id
+          |  +--rw nt:dest-tp?
+          |        -> ../../../nw:node[nw:node-id=current()
+          |          /../dest-node]/termination-point/tp-id
+          +--rw tet:te!
+
+
+
+Ahlberg, et al.          Expires 2 November 2022               [Page 23]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
+             +--rw (tet:bundle-stack-level)?
+             |  +--:(tet:bundle)
+             |     +--rw tet:bundled-links
+             |        +--rw tet:bundled-link* [sequence]
+             |           +--rw tet:sequence      uint32
+             |           +--rw tet:src-tp-ref?   -> ../../../../../
+             |           |     nw:node[nw:node-id current()/../../..
+             |           |     /../nt:source/source-node]/
+             |           |     termination-point/tp-id
+             |           +--rw tet:des-tp-ref?   -> ../../../../../
+             |                 nw:node[nw:node-id = current()/../../
+             |                 ../../nt:destination/dest-node]/
+             |                 termination-point/tp-id
+             +--rw tet:te-link-attributes
+             |  +--rw tet:name?            string
+             |  +--rw tet:admin-status?    te-types:te-admin-status
+             |  +--rw tet:max-link-bandwidth
+             |  |  +--rw tet:te-bandwidth
+             |  |     +--rw (tet:technology)?
+             |  |        +--:(mwtopo:microwave)
+             |  |           +--ro mwtopo:mw-bandwidth? uint64
+             |  +--rw mwtopo:mw-link-choice
+             |  |   +--rw (mwtopo:mw-link-option)?
+             |  |     +--:(mwtopo:microwave-radio-link)
+             |  |     |  +--rw mwtopo:microwave-radio-link!
+             |  |     |     +--rw mwtopo:mode?   identityref
+             |  |     +--:(mwtopo:microwave-carrier)
+             |  |        +--rw mwtopo:microwave-carrier!
+             |  |           +--rw mwtopo:tx-frequency?       uint32
+             |  |           +--rw mwtopo:rx-frequency?       uint32
+             |  |           +--rw mwtopo:channel-separation? uint32
+             |  |           +--rw mwtopo:actual-tx-cm?       identityref
+             |  |           +--rw mwtopo:actual-snir?        decimal64
+             |  |           +--rw mwtopo:actual-transmitted-level? power
+             |  +--rw bwatopo:link-availability* [availability]
+             |  |  +--rw bwatopo:availability      decimal64
+             |  |  +--rw bwatopo:link-bandwidth?   uint64
+             |  +--rw bwatopo:actual-bandwidth?    yang:gauge64
+             +--ro tet:oper-status?         te-types:te-oper-status
 
 A.2.  A topology with single microwave radio link
 
@@ -1156,6 +1338,14 @@ A.2.  A topology with single microwave radio link
    topologies could be as shown in Figure 3 below.  Note that the figure
    just shows an example, there might be other possibilities to
    demonstrate such a topology.  The example of the instantiation
+
+
+
+Ahlberg, et al.          Expires 2 November 2022               [Page 24]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
    encoded in JSON is using only a selected subset of the leafs from the
    L2 topology model [RFC8944] and the Microwave Interface Management
    Model [RFC8561].
@@ -1204,6 +1394,14 @@ A.2.  A topology with single microwave radio link
    | |mw-N1-CTP3 |************************|    CT-3    | |
    | +-----------+ |                    | +------------+ |
    +---------------+                    +----------------+
+
+
+
+Ahlberg, et al.          Expires 2 November 2022               [Page 25]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
     Figure 4: References from the topology model information to
     the associated interface management model information
 
@@ -1213,8 +1411,8 @@ A.2.  A topology with single microwave radio link
       the reference to the associated interface management
       information, is encoded in JSON as follows:
 
-   <CODE BEGINS>
-   file "example-fold.json"
+   =============== NOTE: '\' line wrapping per RFC 8792 ================
+
    {
      "ietf-network:networks": {
        "network": [
@@ -1252,6 +1450,14 @@ A.2.  A topology with single microwave radio link
                    ]
                  }
                ]
+
+
+
+Ahlberg, et al.          Expires 2 November 2022               [Page 26]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
              },
              {
                "node-id": "L2-N2",
@@ -1300,6 +1506,14 @@ A.2.  A topology with single microwave radio link
            "network-types": {
              "ietf-te-topology:te-topology": {
                "ietf-microwave-topology:mw-topology": {
+
+
+
+Ahlberg, et al.          Expires 2 November 2022               [Page 27]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
                }
              }
            },
@@ -1337,8 +1551,8 @@ A.2.  A topology with single microwave radio link
                      "ietf-microwave-topology:mw-tp-choice": {
                        "microwave-rltp": {}
                      },
-                     "ietf-tp-interface-reference-topology:tp-to-interface-p
-   ath":"RLT-1"
+                     "ietf-tp-interface-reference-topology:tp-to-interf\
+   ace-path":"RLT-1"
                    }
                  },
                  {
@@ -1348,8 +1562,16 @@ A.2.  A topology with single microwave radio link
                      "ietf-microwave-topology:mw-tp-choice": {
                        "microwave-ctp": {}
                      },
-                     "ietf-tp-interface-reference-topology:tp-to-interface-p
-   ath":"CT-1"
+
+
+
+Ahlberg, et al.          Expires 2 November 2022               [Page 28]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
+                     "ietf-tp-interface-reference-topology:tp-to-interf\
+   ace-path":"CT-1"
                    }
                  },
                  {
@@ -1359,8 +1581,8 @@ A.2.  A topology with single microwave radio link
                      "ietf-microwave-topology:mw-tp-choice": {
                        "microwave-ctp": {}
                      },
-                     "ietf-tp-interface-reference-topology:tp-to-interface-p
-   ath":"CT-3"
+                     "ietf-tp-interface-reference-topology:tp-to-interf\
+   ace-path":"CT-3"
                    }
                  }
                ]
@@ -1393,9 +1615,17 @@ A.2.  A topology with single microwave radio link
                      "ietf-microwave-topology:mw-tp-choice": {
                        "microwave-rltp": {}
                      },
-                     "ietf-tp-interface-reference-topology:tp-to-interface-p
-   ath":"RLT-2"
+                     "ietf-tp-interface-reference-topology:tp-to-interf\
+   ace-path":"RLT-2"
                    }
+
+
+
+Ahlberg, et al.          Expires 2 November 2022               [Page 29]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
                  },
                  {
                    "tp-id": "mw-N2-CTP2",
@@ -1404,8 +1634,8 @@ A.2.  A topology with single microwave radio link
                      "ietf-microwave-topology:mw-tp-choice": {
                        "microwave-ctp": {}
                      },
-                     "ietf-tp-interface-reference-topology:tp-to-interface-p
-   ath":"CT-2"
+                     "ietf-tp-interface-reference-topology:tp-to-interf\
+   ace-path":"CT-2"
                    }
                  },
                  {
@@ -1415,8 +1645,8 @@ A.2.  A topology with single microwave radio link
                      "ietf-microwave-topology:mw-tp-choice": {
                        "microwave-ctp": {}
                      },
-                     "ietf-tp-interface-reference-topology:tp-to-interface-p
-   ath":"CT-4"
+                     "ietf-tp-interface-reference-topology:tp-to-interf\
+   ace-path":"CT-4"
                    }
                  }
                ]
@@ -1444,13 +1674,21 @@ A.2.  A topology with single microwave radio link
                      {
                        "sequence": 2,
                        "src-tp-ref": "mw-N1-CTP3",
+
+
+
+Ahlberg, et al.          Expires 2 November 2022               [Page 30]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
                        "des-tp-ref": "mw-N2-CTP4"
                      }
                    ]
                  },
                  "te-link-attributes": {
-                   "ietf-bandwidth-availability-topology:link-availability":
-    [
+                   "ietf-bandwidth-availability-topology:link-availabil\
+   ity": [
                      {
                        "availability": "0.999",
                        "link-bandwidth": "1572864"
@@ -1480,8 +1718,8 @@ A.2.  A topology with single microwave radio link
                },
                "ietf-te-topology:te": {
                  "te-link-attributes": {
-                   "ietf-bandwidth-availability-topology:link-availability":
-    [
+                   "ietf-bandwidth-availability-topology:link-availabil\
+   ity": [
                      {
                        "availability": "0.99",
                        "link-bandwidth": "1048576"
@@ -1492,6 +1730,14 @@ A.2.  A topology with single microwave radio link
                        "tx-frequency": 10728000,
                        "rx-frequency": 10615000,
                        "channel-separation": 28000
+
+
+
+Ahlberg, et al.          Expires 2 November 2022               [Page 31]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
                      }
                    }
                  }
@@ -1509,8 +1755,8 @@ A.2.  A topology with single microwave radio link
                },
                "ietf-te-topology:te": {
                  "te-link-attributes": {
-                   "ietf-bandwidth-availability-topology:link-availability":
-    [
+                   "ietf-bandwidth-availability-topology:link-availabil\
+   ity": [
                      {
                        "availability": "0.99",
                        "link-bandwidth": "1048576"
@@ -1540,6 +1786,14 @@ A.2.  A topology with single microwave radio link
          {
            "name": "L2Interface2",
            "description": "'Ethernet Interface 2'",
+
+
+
+Ahlberg, et al.          Expires 2 November 2022               [Page 32]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
            "type": "iana-if-type:ethernetCsmacd"
          },
          {
@@ -1588,6 +1842,14 @@ A.2.  A topology with single microwave radio link
            "ietf-microwave-radio-link:rtpc": {
              "maximum-nominal-power": "20.0"
            },
+
+
+
+Ahlberg, et al.          Expires 2 November 2022               [Page 33]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
            "ietf-microwave-radio-link:single": {
              "selected-cm": "ietf-microwave-types:qam-512"
            }
@@ -1623,10 +1885,9 @@ A.2.  A topology with single microwave radio link
        ]
      }
    }
-   <CODE ENDS>
 
-   <CODE BEGINS>
-   file "exampleOnePlusOne-fold.json"
+   =============== NOTE: '\' line wrapping per RFC 8792 ================
+
    {
      "ietf-interfaces:interfaces": {
        "interface": [
@@ -1637,6 +1898,14 @@ A.2.  A topology with single microwave radio link
          },
          {
            "name": "L2Interface2",
+
+
+
+Ahlberg, et al.          Expires 2 November 2022               [Page 34]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
            "description": "'Ethernet Interface 2'",
            "type": "iana-if-type:ethernetCsmacd"
          },
@@ -1644,8 +1913,8 @@ A.2.  A topology with single microwave radio link
            "name": "RLT-1",
            "description": "'Radio Link Terminal 1'",
            "type": "iana-if-type:microwaveRadioLinkTerminal",
-           "ietf-microwave-radio-link:mode": "ietf-microwave-types:one-plus-
-   one",
+           "ietf-microwave-radio-link:mode": "ietf-microwave-types:one-\
+   plus-one",
            "ietf-microwave-radio-link:carrier-terminations": [
              "CT-1",
              "CT-3"
@@ -1655,8 +1924,8 @@ A.2.  A topology with single microwave radio link
            "name": "RLT-2",
            "description": "'Radio Link Terminal 2'",
            "type": "iana-if-type:microwaveRadioLinkTerminal",
-           "ietf-microwave-radio-link:mode": "ietf-microwave-types:one-plus-
-   one",
+           "ietf-microwave-radio-link:mode": "ietf-microwave-types:one-\
+   plus-one",
            "ietf-microwave-radio-link:carrier-terminations": [
              "CT-2",
              "CT-4"
@@ -1685,6 +1954,14 @@ A.2.  A topology with single microwave radio link
            "ietf-microwave-radio-link:duplex-distance": 644000,
            "ietf-microwave-radio-link:channel-separation": 28000,
            "ietf-microwave-radio-link:rtpc": {
+
+
+
+Ahlberg, et al.          Expires 2 November 2022               [Page 35]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
              "maximum-nominal-power": "20.0"
            },
            "ietf-microwave-radio-link:adaptive": {
@@ -1733,6 +2010,14 @@ A.2.  A topology with single microwave radio link
                "ietf-eth-te-topology:eth-tran-topology": {}
              }
            },
+
+
+
+Ahlberg, et al.          Expires 2 November 2022               [Page 36]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
            "supporting-network": [
              {
                "network-ref": "mw-network"
@@ -1781,6 +2066,14 @@ A.2.  A topology with single microwave radio link
                  }
                ]
              }
+
+
+
+Ahlberg, et al.          Expires 2 November 2022               [Page 37]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
            ],
            "ietf-network-topology:link": [
              {
@@ -1829,6 +2122,14 @@ A.2.  A topology with single microwave radio link
                    "supporting-termination-point": [
                      {
                        "network-ref": "mw-network",
+
+
+
+Ahlberg, et al.          Expires 2 November 2022               [Page 38]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
                        "node-ref": "mw-N1",
                        "tp-ref": "mw-N1-CTP1"
                      },
@@ -1843,8 +2144,8 @@ A.2.  A topology with single microwave radio link
                      "ietf-microwave-topology:mw-tp-choice": {
                        "microwave-rltp": {}
                      },
-                     "ietf-tp-interface-reference-topology:tp-to-interface-p
-   ath": "RLT-1"
+                     "ietf-tp-interface-reference-topology:tp-to-interf\
+   ace-path": "RLT-1"
                    }
                  },
                  {
@@ -1854,8 +2155,8 @@ A.2.  A topology with single microwave radio link
                      "ietf-microwave-topology:mw-tp-choice": {
                        "microwave-ctp": {}
                      },
-                     "ietf-tp-interface-reference-topology:tp-to-interface-p
-   ath": "CT-1"
+                     "ietf-tp-interface-reference-topology:tp-to-interf\
+   ace-path": "CT-1"
                    }
                  },
                  {
@@ -1865,8 +2166,8 @@ A.2.  A topology with single microwave radio link
                      "ietf-microwave-topology:mw-tp-choice": {
                        "microwave-ctp": {}
                      },
-                     "ietf-tp-interface-reference-topology:tp-to-interface-p
-   ath": "CT-3"
+                     "ietf-tp-interface-reference-topology:tp-to-interf\
+   ace-path": "CT-3"
                    }
                  }
                ]
@@ -1877,6 +2178,14 @@ A.2.  A topology with single microwave radio link
                  {
                    "network-ref": "mw-network",
                    "node-ref": "mw-N2"
+
+
+
+Ahlberg, et al.          Expires 2 November 2022               [Page 39]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
                  }
                ],
                "ietf-network-topology:termination-point": [
@@ -1899,8 +2208,8 @@ A.2.  A topology with single microwave radio link
                      "ietf-microwave-topology:mw-tp-choice": {
                        "microwave-rltp": {}
                      },
-                     "ietf-tp-interface-reference-topology:tp-to-interface-p
-   ath": "RLT-2"
+                     "ietf-tp-interface-reference-topology:tp-to-interf\
+   ace-path": "RLT-2"
                    }
                  },
                  {
@@ -1910,8 +2219,8 @@ A.2.  A topology with single microwave radio link
                      "ietf-microwave-topology:mw-tp-choice": {
                        "microwave-ctp": {}
                      },
-                     "ietf-tp-interface-reference-topology:tp-to-interface-p
-   ath": "CT-2"
+                     "ietf-tp-interface-reference-topology:tp-to-interf\
+   ace-path": "CT-2"
                    }
                  },
                  {
@@ -1921,10 +2230,18 @@ A.2.  A topology with single microwave radio link
                      "ietf-microwave-topology:mw-tp-choice": {
                        "microwave-ctp": {}
                      },
-                     "ietf-tp-interface-reference-topology:tp-to-interface-p
-   ath": "CT-4"
+                     "ietf-tp-interface-reference-topology:tp-to-interf\
+   ace-path": "CT-4"
                    }
                  }
+
+
+
+Ahlberg, et al.          Expires 2 November 2022               [Page 40]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
                ]
              }
            ],
@@ -1955,8 +2272,8 @@ A.2.  A topology with single microwave radio link
                    ]
                  },
                  "te-link-attributes": {
-                   "ietf-bandwidth-availability-topology:link-availability":
-    [
+                   "ietf-bandwidth-availability-topology:link-availabil\
+   ity": [
                      {
                        "availability": "0.999",
                        "link-bandwidth": "998423"
@@ -1973,6 +2290,14 @@ A.2.  A topology with single microwave radio link
                    }
                  }
                }
+
+
+
+Ahlberg, et al.          Expires 2 November 2022               [Page 41]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
              },
              {
                "link-id": "mwc-N1-N2-A",
@@ -1986,8 +2311,8 @@ A.2.  A topology with single microwave radio link
                },
                "ietf-te-topology:te": {
                  "te-link-attributes": {
-                   "ietf-bandwidth-availability-topology:link-availability":
-    [
+                   "ietf-bandwidth-availability-topology:link-availabil\
+   ity": [
                      {
                        "availability": "0.99",
                        "link-bandwidth": "998423"
@@ -2019,8 +2344,16 @@ A.2.  A topology with single microwave radio link
                },
                "ietf-te-topology:te": {
                  "te-link-attributes": {
-                   "ietf-bandwidth-availability-topology:link-availability":
-    [
+                   "ietf-bandwidth-availability-topology:link-availabil\
+   ity": [
+
+
+
+Ahlberg, et al.          Expires 2 November 2022               [Page 42]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
                      {
                        "availability": "0.99",
                        "link-bandwidth": "998423"
@@ -2046,7 +2379,6 @@ A.2.  A topology with single microwave radio link
      }
    }
    > quit
-   <CODE ENDS>
 
    Note that the examples above show one particular link
    (unidirectional) and not a complete network topology.
@@ -2055,35 +2387,78 @@ Authors' Addresses
 
    Jonas Ahlberg
    Ericsson
-
    Email: jonas.ahlberg@ericsson.com
 
 
    Scott Mansfield
    Ericsson
-
    Email: scott.mansfield@ericsson.com
 
 
    Min Ye
    Huawei Technologies
-
    Email: amy.yemin@huawei.com
 
 
    Italo Busi
    Huawei Technologies
 
+
+
+Ahlberg, et al.          Expires 2 November 2022               [Page 43]
+
+Internet-Draft        Microwave Topology YANG Model             May 2022
+
+
    Email: italo.busi@huawei.com
 
 
    Xi Li
    NEC Laboratories Europe
-
    Email: xi.li@neclab.eu
 
 
    Daniela Spreafico
    Nokia - IT
-
    Email: daniela.spreafico@nokia.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ahlberg, et al.          Expires 2 November 2022               [Page 44]

--- a/example.txt
+++ b/example.txt
@@ -1,0 +1,410 @@
+=============== NOTE: '\' line wrapping per RFC 8792 ================
+
+{
+  "ietf-network:networks": {
+    "network": [
+      {
+        "network-id": "L2-network",
+        "network-types": {
+          "ietf-te-topology:te-topology": {
+            "ietf-eth-te-topology:eth-tran-topology": {
+            }
+          }
+        },
+        "supporting-network": [
+          {
+            "network-ref": "mw-network"
+          }
+        ],
+        "node": [
+          {
+            "node-id": "L2-N1",
+            "supporting-node": [
+              {
+                "network-ref": "mw-network",
+                "node-ref": "mw-N1"
+              }
+            ],
+            "ietf-network-topology:termination-point": [
+              {
+                "tp-id": "L2-N1-TP1",
+                "supporting-termination-point": [
+                  {
+                    "network-ref": "mw-network",
+                    "node-ref": "mw-N1",
+                    "tp-ref": "mw-N1-RLTP1"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "node-id": "L2-N2",
+            "supporting-node": [
+              {
+                "network-ref": "mw-network",
+                "node-ref": "mw-N2"
+              }
+            ],
+            "ietf-network-topology:termination-point": [
+              {
+                "tp-id": "L2-N2-TP2",
+                "supporting-termination-point": [
+                  {
+                    "network-ref": "mw-network",
+                    "node-ref": "mw-N2",
+                    "tp-ref": "mw-N2-RLTP2"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "ietf-network-topology:link": [
+          {
+            "link-id": "L2-N1-N2",
+            "source": {
+              "source-node": "L2-N1",
+              "source-tp": "L2-N1-TP1"
+            },
+            "destination": {
+              "dest-node": "L2-N2",
+              "dest-tp": "L2-N2-TP2"
+            },
+            "supporting-link": [
+              {
+                "network-ref": "mw-network",
+                "link-ref": "mwrl-N1-N2"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "network-id": "mw-network",
+        "network-types": {
+          "ietf-te-topology:te-topology": {
+            "ietf-microwave-topology:mw-topology": {
+            }
+          }
+        },
+        "supporting-network": [
+          {
+            "network-ref": "mw-network"
+          }
+        ],
+        "node": [
+          {
+            "node-id": "mw-N1",
+            "supporting-node": [
+              {
+                "network-ref": "mw-network",
+                "node-ref": "mw-N1"
+              }
+            ],
+            "ietf-network-topology:termination-point": [
+              {
+                "tp-id": "mw-N1-RLTP1",
+                "supporting-termination-point": [
+                  {
+                    "network-ref": "mw-network",
+                    "node-ref": "mw-N1",
+                    "tp-ref": "mw-N1-CTP1"
+                  },
+                  {
+                    "network-ref": "mw-network",
+                    "node-ref": "mw-N1",
+                    "tp-ref": "mw-N1-CTP3"
+                  }
+                ],
+                "ietf-te-topology:te-tp-id": "10.10.10.1",
+                "ietf-te-topology:te": {
+                  "ietf-microwave-topology:mw-tp-choice": {
+                    "microwave-rltp": {}
+                  },
+                  "ietf-tp-interface-reference-topology:tp-to-interf\
+ace-path":"RLT-1"
+                }
+              },
+              {
+                "tp-id": "mw-N1-CTP1",
+                "ietf-te-topology:te-tp-id": 1,
+                "ietf-te-topology:te": {
+                  "ietf-microwave-topology:mw-tp-choice": {
+                    "microwave-ctp": {}
+                  },
+                  "ietf-tp-interface-reference-topology:tp-to-interf\
+ace-path":"CT-1"
+                }
+              },
+              {
+                "tp-id": "mw-N1-CTP3",
+                "ietf-te-topology:te-tp-id": 2,
+                "ietf-te-topology:te": {
+                  "ietf-microwave-topology:mw-tp-choice": {
+                    "microwave-ctp": {}
+                  },
+                  "ietf-tp-interface-reference-topology:tp-to-interf\
+ace-path":"CT-3"
+                }
+              }
+            ]
+          },
+          {
+            "node-id": "mw-N2",
+            "supporting-node": [
+              {
+                "network-ref": "mw-network",
+                "node-ref": "mw-N2"
+              }
+            ],
+            "ietf-network-topology:termination-point": [
+              {
+                "tp-id": "mw-N2-RLTP2",
+                "supporting-termination-point": [
+                  {
+                    "network-ref": "mw-network",
+                    "node-ref": "mw-N2",
+                    "tp-ref": "mw-N2-CTP2"
+                  },
+                  {
+                    "network-ref": "mw-network",
+                    "node-ref": "mw-N2",
+                    "tp-ref": "mw-N2-CTP4"
+                  }
+                ],
+                "ietf-te-topology:te-tp-id": "10.10.10.1",
+                "ietf-te-topology:te": {
+                  "ietf-microwave-topology:mw-tp-choice": {
+                    "microwave-rltp": {}
+                  },
+                  "ietf-tp-interface-reference-topology:tp-to-interf\
+ace-path":"RLT-2"
+                }
+              },
+              {
+                "tp-id": "mw-N2-CTP2",
+                "ietf-te-topology:te-tp-id": 1,
+                "ietf-te-topology:te": {
+                  "ietf-microwave-topology:mw-tp-choice": {
+                    "microwave-ctp": {}
+                  },
+                  "ietf-tp-interface-reference-topology:tp-to-interf\
+ace-path":"CT-2"
+                }
+              },
+              {
+                "tp-id": "mw-N2-CTP4",
+                "ietf-te-topology:te-tp-id": 2,
+                "ietf-te-topology:te": {
+                  "ietf-microwave-topology:mw-tp-choice": {
+                    "microwave-ctp": {}
+                  },
+                  "ietf-tp-interface-reference-topology:tp-to-interf\
+ace-path":"CT-4"
+                }
+              }
+            ]
+          }
+        ],
+        "ietf-network-topology:link": [
+          {
+            "link-id": "mwrl-N1-N2",
+            "source": {
+              "source-node": "mw-N1",
+              "source-tp": "mw-N1-RLTP1"
+            },
+            "destination": {
+              "dest-node": "mw-N2",
+              "dest-tp": "mw-N2-RLTP2"
+            },
+            "ietf-te-topology:te": {
+              "bundled-links": {
+                "bundled-link": [
+                  {
+                    "sequence": 1,
+                    "src-tp-ref": "mw-N1-CTP1",
+                    "des-tp-ref": "mw-N2-CTP2"
+                  },
+                  {
+                    "sequence": 2,
+                    "src-tp-ref": "mw-N1-CTP3",
+                    "des-tp-ref": "mw-N2-CTP4"
+                  }
+                ]
+              },
+              "te-link-attributes": {
+                "ietf-bandwidth-availability-topology:link-availabil\
+ity": [
+                  {
+                    "availability": "0.999",
+                    "link-bandwidth": "1572864"
+                  },
+                  {
+                    "availability": "0.95",
+                    "link-bandwidth": "2097152"
+                  }
+                ],
+                "ietf-microwave-topology:mw-link-choice": {
+                  "microwave-radio-link": {
+                    "mode": "ietf-microwave-types:two-plus-zero"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "link-id": "mwc-N1-N2-A",
+            "source": {
+              "source-node": "mw-N1",
+              "source-tp": "mw-N1-CTP1"
+            },
+            "destination": {
+              "dest-node": "mw-N2",
+              "dest-tp": "mw-N2-CTP2"
+            },
+            "ietf-te-topology:te": {
+              "te-link-attributes": {
+                "ietf-bandwidth-availability-topology:link-availabil\
+ity": [
+                  {
+                    "availability": "0.99",
+                    "link-bandwidth": "1048576"
+                  }
+                ],
+                "ietf-microwave-topology:mw-link-choice": {
+                  "microwave-carrier": {
+                    "tx-frequency": 10728000,
+                    "rx-frequency": 10615000,
+                    "channel-separation": 28000
+                  }
+                }
+              }
+            }
+          },
+          {
+            "link-id": "mwc-N1-N2-B",
+            "source": {
+              "source-node": "mw-N1",
+              "source-tp": "mw-N1-CTP3"
+            },
+            "destination": {
+              "dest-node": "mw-N2",
+              "dest-tp": "mw-N2-CTP4"
+            },
+            "ietf-te-topology:te": {
+              "te-link-attributes": {
+                "ietf-bandwidth-availability-topology:link-availabil\
+ity": [
+                  {
+                    "availability": "0.99",
+                    "link-bandwidth": "1048576"
+                  }
+                ],
+                "ietf-microwave-topology:mw-link-choice": {
+                  "microwave-carrier": {
+                    "tx-frequency": 10528000,
+                    "rx-frequency": 10415000,
+                    "channel-separation": 28000
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "ietf-interfaces:interfaces": {
+    "interface": [
+      {
+        "name": "L2Interface1",
+        "description": "'Ethernet Interface 1'",
+        "type": "iana-if-type:ethernetCsmacd"
+      },
+      {
+        "name": "L2Interface2",
+        "description": "'Ethernet Interface 2'",
+        "type": "iana-if-type:ethernetCsmacd"
+      },
+      {
+        "name": "RLT-1",
+        "description": "'Radio Link Terminal 1'",
+        "type": "iana-if-type:microwaveRadioLinkTerminal",
+        "ietf-microwave-radio-link:mode":
+        "ietf-microwave-types:one-plus-zero",
+        "ietf-microwave-radio-link:carrier-terminations": [
+          "CT-1",
+          "CT-3"
+        ]
+      },
+      {
+        "name": "RLT-2",
+        "description": "'Radio Link Terminal 2'",
+        "type": "iana-if-type:microwaveRadioLinkTerminal",
+        "ietf-microwave-radio-link:mode":
+        "ietf-microwave-types:one-plus-zero",
+        "ietf-microwave-radio-link:carrier-terminations": [
+          "CT-2",
+          "CT-4"
+        ]
+      },
+      {
+        "name": "CT-1",
+        "description": "'Carrier Termination 1'",
+        "type": "iana-if-type:microwaveCarrierTermination",
+        "ietf-microwave-radio-link:tx-frequency": 10728000,
+        "ietf-microwave-radio-link:duplex-distance": 644000,
+        "ietf-microwave-radio-link:channel-separation": 28000,
+        "ietf-microwave-radio-link:rtpc": {
+          "maximum-nominal-power": "20.0"
+        },
+        "ietf-microwave-radio-link:single": {
+          "selected-cm": "ietf-microwave-types:qam-512"
+        }
+      },
+      {
+        "name": "CT-3",
+        "description": "'Carrier Termination 3'",
+        "type": "iana-if-type:microwaveCarrierTermination",
+        "ietf-microwave-radio-link:tx-frequency": 10728000,
+        "ietf-microwave-radio-link:duplex-distance": 644000,
+        "ietf-microwave-radio-link:channel-separation": 28000,
+        "ietf-microwave-radio-link:rtpc": {
+          "maximum-nominal-power": "20.0"
+        },
+        "ietf-microwave-radio-link:single": {
+          "selected-cm": "ietf-microwave-types:qam-512"
+        }
+      },
+      {
+        "name": "CT-2",
+        "description": "'Carrier Termination 2'",
+        "type": "iana-if-type:microwaveCarrierTermination",
+        "ietf-microwave-radio-link:tx-frequency": 10728000,
+        "ietf-microwave-radio-link:duplex-distance": 644000,
+        "ietf-microwave-radio-link:channel-separation": 28000,
+        "ietf-microwave-radio-link:rtpc": {
+          "maximum-nominal-power": "20.0"
+        },
+        "ietf-microwave-radio-link:single": {
+          "selected-cm": "ietf-microwave-types:qam-512"
+        }
+      },
+      {
+        "name": "CT-4",
+        "description": "'Carrier Termination 4'",
+        "type": "iana-if-type:microwaveCarrierTermination",
+        "ietf-microwave-radio-link:tx-frequency": 10728000,
+        "ietf-microwave-radio-link:duplex-distance": 644000,
+        "ietf-microwave-radio-link:channel-separation": 28000,
+        "ietf-microwave-radio-link:rtpc": {
+          "maximum-nominal-power": "20.0"
+        },
+        "ietf-microwave-radio-link:single": {
+          "selected-cm": "ietf-microwave-types:qam-512"
+        }
+      }
+    ]
+  }
+}

--- a/example1p1.txt
+++ b/example1p1.txt
@@ -1,0 +1,421 @@
+=============== NOTE: '\' line wrapping per RFC 8792 ================
+
+{
+  "ietf-interfaces:interfaces": {
+    "interface": [
+      {
+        "name": "L2Interface1",
+        "description": "'Ethernet Interface 1'",
+        "type": "iana-if-type:ethernetCsmacd"
+      },
+      {
+        "name": "L2Interface2",
+        "description": "'Ethernet Interface 2'",
+        "type": "iana-if-type:ethernetCsmacd"
+      },
+      {
+        "name": "RLT-1",
+        "description": "'Radio Link Terminal 1'",
+        "type": "iana-if-type:microwaveRadioLinkTerminal",
+        "ietf-microwave-radio-link:mode": "ietf-microwave-types:one-\
+plus-one",
+        "ietf-microwave-radio-link:carrier-terminations": [
+          "CT-1",
+          "CT-3"
+        ]
+      },
+      {
+        "name": "RLT-2",
+        "description": "'Radio Link Terminal 2'",
+        "type": "iana-if-type:microwaveRadioLinkTerminal",
+        "ietf-microwave-radio-link:mode": "ietf-microwave-types:one-\
+plus-one",
+        "ietf-microwave-radio-link:carrier-terminations": [
+          "CT-2",
+          "CT-4"
+        ]
+      },
+      {
+        "name": "CT-1",
+        "description": "'Carrier Termination 1'",
+        "type": "iana-if-type:microwaveCarrierTermination",
+        "ietf-microwave-radio-link:tx-frequency": 10728000,
+        "ietf-microwave-radio-link:duplex-distance": 644000,
+        "ietf-microwave-radio-link:channel-separation": 28000,
+        "ietf-microwave-radio-link:rtpc": {
+          "maximum-nominal-power": "20.0"
+        },
+        "ietf-microwave-radio-link:adaptive": {
+          "selected-min-acm": "ietf-microwave-types:qam-256",
+          "selected-max-acm": "ietf-microwave-types:qam-512"
+        }
+      },
+      {
+        "name": "CT-3",
+        "description": "'Carrier Termination 3'",
+        "type": "iana-if-type:microwaveCarrierTermination",
+        "ietf-microwave-radio-link:tx-frequency": 10728000,
+        "ietf-microwave-radio-link:duplex-distance": 644000,
+        "ietf-microwave-radio-link:channel-separation": 28000,
+        "ietf-microwave-radio-link:rtpc": {
+          "maximum-nominal-power": "20.0"
+        },
+        "ietf-microwave-radio-link:adaptive": {
+          "selected-min-acm": "ietf-microwave-types:qam-256",
+          "selected-max-acm": "ietf-microwave-types:qam-512"
+        }
+      },
+      {
+        "name": "CT-2",
+        "description": "'Carrier Termination 2'",
+        "type": "iana-if-type:microwaveCarrierTermination",
+        "ietf-microwave-radio-link:tx-frequency": 10615000,
+        "ietf-microwave-radio-link:duplex-distance": 644000,
+        "ietf-microwave-radio-link:channel-separation": 28000,
+        "ietf-microwave-radio-link:rtpc": {
+          "maximum-nominal-power": "20.0"
+        },
+        "ietf-microwave-radio-link:adaptive": {
+          "selected-min-acm": "ietf-microwave-types:qam-256",
+          "selected-max-acm": "ietf-microwave-types:qam-512"
+        }
+      },
+      {
+        "name": "CT-4",
+        "description": "'Carrier Termination 4'",
+        "type": "iana-if-type:microwaveCarrierTermination",
+        "ietf-microwave-radio-link:tx-frequency": 10615000,
+        "ietf-microwave-radio-link:duplex-distance": 644000,
+        "ietf-microwave-radio-link:channel-separation": 28000,
+        "ietf-microwave-radio-link:rtpc": {
+          "maximum-nominal-power": "20.0"
+        },
+        "ietf-microwave-radio-link:adaptive": {
+          "selected-min-acm": "ietf-microwave-types:qam-256",
+          "selected-max-acm": "ietf-microwave-types:qam-512"
+        }
+      }
+    ]
+  },
+  "ietf-network:networks": {
+    "network": [
+      {
+        "network-id": "L2-network",
+        "network-types": {
+          "ietf-te-topology:te-topology": {
+            "ietf-eth-te-topology:eth-tran-topology": {}
+          }
+        },
+        "supporting-network": [
+          {
+            "network-ref": "mw-network"
+          }
+        ],
+        "node": [
+          {
+            "node-id": "L2-N1",
+            "supporting-node": [
+              {
+                "network-ref": "mw-network",
+                "node-ref": "mw-N1"
+              }
+            ],
+            "ietf-network-topology:termination-point": [
+              {
+                "tp-id": "L2-N1-TP1",
+                "supporting-termination-point": [
+                  {
+                    "network-ref": "mw-network",
+                    "node-ref": "mw-N1",
+                    "tp-ref": "mw-N1-RLTP1"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "node-id": "L2-N2",
+            "supporting-node": [
+              {
+                "network-ref": "mw-network",
+                "node-ref": "mw-N2"
+              }
+            ],
+            "ietf-network-topology:termination-point": [
+              {
+                "tp-id": "L2-N2-TP2",
+                "supporting-termination-point": [
+                  {
+                    "network-ref": "mw-network",
+                    "node-ref": "mw-N2",
+                    "tp-ref": "mw-N2-RLTP2"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "ietf-network-topology:link": [
+          {
+            "link-id": "L2-N1-N2",
+            "source": {
+              "source-node": "L2-N1",
+              "source-tp": "L2-N1-TP1"
+            },
+            "destination": {
+              "dest-node": "L2-N2",
+              "dest-tp": "L2-N2-TP2"
+            },
+            "supporting-link": [
+              {
+                "network-ref": "mw-network",
+                "link-ref": "mwrl-N1-N2"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "network-id": "mw-network",
+        "network-types": {
+          "ietf-te-topology:te-topology": {
+            "ietf-microwave-topology:mw-topology": {}
+          }
+        },
+        "supporting-network": [
+          {
+            "network-ref": "mw-network"
+          }
+        ],
+        "node": [
+          {
+            "node-id": "mw-N1",
+            "supporting-node": [
+              {
+                "network-ref": "mw-network",
+                "node-ref": "mw-N1"
+              }
+            ],
+            "ietf-network-topology:termination-point": [
+              {
+                "tp-id": "mw-N1-RLTP1",
+                "supporting-termination-point": [
+                  {
+                    "network-ref": "mw-network",
+                    "node-ref": "mw-N1",
+                    "tp-ref": "mw-N1-CTP1"
+                  },
+                  {
+                    "network-ref": "mw-network",
+                    "node-ref": "mw-N1",
+                    "tp-ref": "mw-N1-CTP3"
+                  }
+                ],
+                "ietf-te-topology:te-tp-id": "10.10.10.1",
+                "ietf-te-topology:te": {
+                  "ietf-microwave-topology:mw-tp-choice": {
+                    "microwave-rltp": {}
+                  },
+                  "ietf-tp-interface-reference-topology:tp-to-interf\
+ace-path": "RLT-1"
+                }
+              },
+              {
+                "tp-id": "mw-N1-CTP1",
+                "ietf-te-topology:te-tp-id": 1,
+                "ietf-te-topology:te": {
+                  "ietf-microwave-topology:mw-tp-choice": {
+                    "microwave-ctp": {}
+                  },
+                  "ietf-tp-interface-reference-topology:tp-to-interf\
+ace-path": "CT-1"
+                }
+              },
+              {
+                "tp-id": "mw-N1-CTP3",
+                "ietf-te-topology:te-tp-id": 2,
+                "ietf-te-topology:te": {
+                  "ietf-microwave-topology:mw-tp-choice": {
+                    "microwave-ctp": {}
+                  },
+                  "ietf-tp-interface-reference-topology:tp-to-interf\
+ace-path": "CT-3"
+                }
+              }
+            ]
+          },
+          {
+            "node-id": "mw-N2",
+            "supporting-node": [
+              {
+                "network-ref": "mw-network",
+                "node-ref": "mw-N2"
+              }
+            ],
+            "ietf-network-topology:termination-point": [
+              {
+                "tp-id": "mw-N2-RLTP2",
+                "supporting-termination-point": [
+                  {
+                    "network-ref": "mw-network",
+                    "node-ref": "mw-N2",
+                    "tp-ref": "mw-N2-CTP2"
+                  },
+                  {
+                    "network-ref": "mw-network",
+                    "node-ref": "mw-N2",
+                    "tp-ref": "mw-N2-CTP4"
+                  }
+                ],
+                "ietf-te-topology:te-tp-id": "10.10.10.1",
+                "ietf-te-topology:te": {
+                  "ietf-microwave-topology:mw-tp-choice": {
+                    "microwave-rltp": {}
+                  },
+                  "ietf-tp-interface-reference-topology:tp-to-interf\
+ace-path": "RLT-2"
+                }
+              },
+              {
+                "tp-id": "mw-N2-CTP2",
+                "ietf-te-topology:te-tp-id": 1,
+                "ietf-te-topology:te": {
+                  "ietf-microwave-topology:mw-tp-choice": {
+                    "microwave-ctp": {}
+                  },
+                  "ietf-tp-interface-reference-topology:tp-to-interf\
+ace-path": "CT-2"
+                }
+              },
+              {
+                "tp-id": "mw-N2-CTP4",
+                "ietf-te-topology:te-tp-id": 2,
+                "ietf-te-topology:te": {
+                  "ietf-microwave-topology:mw-tp-choice": {
+                    "microwave-ctp": {}
+                  },
+                  "ietf-tp-interface-reference-topology:tp-to-interf\
+ace-path": "CT-4"
+                }
+              }
+            ]
+          }
+        ],
+        "ietf-network-topology:link": [
+          {
+            "link-id": "mwrl-N1-N2",
+            "source": {
+              "source-node": "mw-N1",
+              "source-tp": "mw-N1-RLTP1"
+            },
+            "destination": {
+              "dest-node": "mw-N2",
+              "dest-tp": "mw-N2-RLTP2"
+            },
+            "ietf-te-topology:te": {
+              "bundled-links": {
+                "bundled-link": [
+                  {
+                    "sequence": 1,
+                    "src-tp-ref": "mw-N1-CTP1",
+                    "des-tp-ref": "mw-N2-CTP2"
+                  },
+                  {
+                    "sequence": 2,
+                    "src-tp-ref": "mw-N1-CTP3",
+                    "des-tp-ref": "mw-N2-CTP4"
+                  }
+                ]
+              },
+              "te-link-attributes": {
+                "ietf-bandwidth-availability-topology:link-availabil\
+ity": [
+                  {
+                    "availability": "0.999",
+                    "link-bandwidth": "998423"
+                  },
+                  {
+                    "availability": "0.99",
+                    "link-bandwidth": "1048576"
+                  }
+                ],
+                "ietf-microwave-topology:mw-link-choice": {
+                  "microwave-radio-link": {
+                    "mode": "ietf-microwave-types:one-plus-one"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "link-id": "mwc-N1-N2-A",
+            "source": {
+              "source-node": "mw-N1",
+              "source-tp": "mw-N1-CTP1"
+            },
+            "destination": {
+              "dest-node": "mw-N2",
+              "dest-tp": "mw-N2-CTP2"
+            },
+            "ietf-te-topology:te": {
+              "te-link-attributes": {
+                "ietf-bandwidth-availability-topology:link-availabil\
+ity": [
+                  {
+                    "availability": "0.99",
+                    "link-bandwidth": "998423"
+                  },
+                  {
+                    "availability": "0.95",
+                    "link-bandwidth": "1048576"
+                  }
+                ],
+                "ietf-microwave-topology:mw-link-choice": {
+                  "microwave-carrier": {
+                    "tx-frequency": 10728000,
+                    "rx-frequency": 10615000,
+                    "channel-separation": 28000
+                  }
+                }
+              }
+            }
+          },
+          {
+            "link-id": "mwc-N1-N2-B",
+            "source": {
+              "source-node": "mw-N1",
+              "source-tp": "mw-N1-CTP3"
+            },
+            "destination": {
+              "dest-node": "mw-N2",
+              "dest-tp": "mw-N2-CTP4"
+            },
+            "ietf-te-topology:te": {
+              "te-link-attributes": {
+                "ietf-bandwidth-availability-topology:link-availabil\
+ity": [
+                  {
+                    "availability": "0.99",
+                    "link-bandwidth": "998423"
+                  },
+                  {
+                    "availability": "0.95",
+                    "link-bandwidth": "1048576"
+                  }
+                ],
+                "ietf-microwave-topology:mw-link-choice": {
+                  "microwave-carrier": {
+                    "tx-frequency": 10728000,
+                    "rx-frequency": 10615000,
+                    "channel-separation": 28000
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+}
+> quit


### PR DESCRIPTION
Folding JSON examples using RFC 8792 tool

Use artwork and sourcecode kramdown instructions for RFC strip

Note 1: RFC 8792 provides instructions (and shell sript) for folding/unfolding files

Note 2: rfcstrip will extract YANG code from txt files and other files (e.g., folded JSON examples) from xml files

Fix #20 
